### PR TITLE
Fix export in foo.js

### DIFF
--- a/generators/app/templates/commands/foo.js
+++ b/generators/app/templates/commands/foo.js
@@ -1,6 +1,6 @@
 var Clapp = require('../modules/clapp-discord');
 
-new Clapp.Command({
+module.exports = new Clapp.Command({
   name: "foo",
   desc: "does foo things",
   fn: (argv, context) => {


### PR DESCRIPTION
The commit to fix #1 broke foo.js by removing `module.exports =`.